### PR TITLE
Fixes for util::rmdir().

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -909,13 +909,14 @@ class util
      * @param  string $dir              The directory to be deleted recursively
      * @param  bool   $traverseSymlinks Delete contents of symlinks recursively
      * @return bool
+     * @throws \RuntimeException
      */
     public static function rmdir($dir, $traverseSymlinks = false)
     {
         if (!file_exists($dir)) {
             return true;
         } elseif (!is_dir($dir)) {
-            throw new \Exception('Given path is not a directory');
+            throw new \RuntimeException('Given path is not a directory');
         }
 
         if (!is_link($dir) || $traverseSymlinks) {
@@ -929,20 +930,29 @@ class util
                 if (is_dir($currentPath)) {
                     self::rmdir($currentPath, $traverseSymlinks);
                 } elseif (!unlink($currentPath)) {
-                    throw new \Exception('Unable to delete ' . $currentPath);
+                    // @codeCoverageIgnoreStart
+                    throw new \RuntimeException('Unable to delete ' . $currentPath);
+                    // @codeCoverageIgnoreEnd
                 }
             }
         }
 
-        if (is_link($dir)) {
+        // Windows treats removing directory symlinks identically to removing directories.
+        if (is_link($dir) && !defined('PHP_WINDOWS_VERSION_MAJOR')) {
             if (!unlink($dir)) {
-                throw new \Exception('Unable to delete ' . $dir);
+                // @codeCoverageIgnoreStart
+                throw new \RuntimeException('Unable to delete ' . $dir);
+                // @codeCoverageIgnoreEnd
             }
         } else {
             if (!rmdir($dir)) {
-                throw new \Exception('Unable to delete ' . $dir);
+                // @codeCoverageIgnoreStart
+                throw new \RuntimeException('Unable to delete ' . $dir);
+                // @codeCoverageIgnoreEnd
             }
         }
+
+        return true;
     }
 
     /**

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -739,5 +739,26 @@ class UtilityPHPTest extends PHPUnit_Framework_TestCase
             $this->assertFalse(is_file($file1));
             $this->assertFalse(is_file($file2));
         }
+
+        // Test symlink traversal.
+        $dir = $dirname . '/test6';
+        $nestedDir = "$dir/nested";
+        $symlink = "$dir/nested-symlink";
+
+        mkdir($dir);
+        mkdir($nestedDir);
+
+        $symlinkStatus = symlink($nestedDir, $symlink);
+        $this->assertTrue($symlinkStatus, 'The test system does not support making symlinks.');
+
+        if (!$symlink) {
+            return;
+        }
+
+        $this->assertTrue(util::rmdir($symlink, true), 'Could not delete a symlinked directory.');
+        $this->assertFalse(file_exists($symlink), 'Could not delete a symlinked directory.');
+        util::rmdir($dir, true);
+        $this->assertFalse(is_dir($dir), 'Could not delete a directory with a symlinked directory inside of it.');
+
     }
 }


### PR DESCRIPTION
- Refactored generic \Exceptions to \RuntimeExceptions.
- Refactored to return true on success (instead of null).
- Fixed the ability to remove symlinks to directories on Windows systems.
